### PR TITLE
Fix immutable access and SafeERC20 API

### DIFF
--- a/src/FeeCollector.sol
+++ b/src/FeeCollector.sol
@@ -49,11 +49,11 @@ contract OptimizedFeeCollector {
     // ====== MODIFIERS ====
     // =====================
     modifier onlyAuthorized() {
+        address _vault = vault;
+        address _owner = owner;
         assembly {
-            let _vault := sload(vault.slot)
-            let _owner := sload(owner.slot)
             let _caller := caller()
-            
+
             if iszero(or(eq(_caller, _vault), eq(_caller, _owner))) {
                 mstore(0x00, 0x82b42900) // NotAuthorized() selector
                 revert(0x1c, 0x04)

--- a/src/UniswapV3Adapter.sol
+++ b/src/UniswapV3Adapter.sol
@@ -140,7 +140,7 @@ contract UniswapV3Adapter is IDEXAdapter {
         IERC20(token0).safeTransferFrom(msg.sender, address(this), amount);
         
         // Approve router
-        IERC20(token0).safeApprove(address(SWAP_ROUTER), amount);
+        IERC20(token0).forceApprove(address(SWAP_ROUTER), amount);
         
         // Set up swap params
         ISwapRouter.ExactInputSingleParams memory params = ISwapRouter.ExactInputSingleParams({
@@ -183,8 +183,8 @@ contract UniswapV3Adapter is IDEXAdapter {
         IERC20(token1).safeTransferFrom(msg.sender, address(this), amount1);
         
         // Approve position manager
-        IERC20(token0).safeApprove(address(POSITION_MANAGER), amount0);
-        IERC20(token1).safeApprove(address(POSITION_MANAGER), amount1);
+        IERC20(token0).forceApprove(address(POSITION_MANAGER), amount0);
+        IERC20(token1).forceApprove(address(POSITION_MANAGER), amount1);
         
         // Order tokens (token0 must be < token1 in Uniswap V3)
         (address orderedToken0, address orderedToken1, uint256 orderedAmount0, uint256 orderedAmount1) = 


### PR DESCRIPTION
## Summary
- avoid direct slot load of immutable `vault`
- update SafeERC20 calls to `forceApprove`

## Testing
- `forge test` *(fails: Compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_688111ce3acc832d8084b3e77db23e0f