### PR TITLE
Fix vault prefunding and limit tests

### DIFF
--- a/src/FeeCollector.sol
+++ b/src/FeeCollector.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.24;
 
 /// @title OptimizedFeeCollector
 /// @notice Ultra gas-optimized fee collection with proper fund transfers
+import {IVault} from "./IVault.sol";
+
 contract OptimizedFeeCollector {
     
     // =====================
@@ -224,7 +226,11 @@ contract OptimizedFeeCollector {
     /// @notice Initialize fee tracking for a new user
     function initializeUser(address user) external onlyAuthorized {
         if (userFeeData[user].lastAccrual == 0) {
-            userFeeData[user].lastAccrual = uint128(block.timestamp);
+            uint256 balance = IVault(vault).convertToAssets(IVault(vault).balanceOf(user));
+            userFeeData[user] = PackedUserFeeData({
+                highWaterMark: uint128(balance),
+                lastAccrual: uint128(block.timestamp)
+            });
         }
     }
 

--- a/src/Vault.sol
+++ b/src/Vault.sol
@@ -162,6 +162,16 @@ contract OptimizedVault is
     function unpause() external onlyOwner {
         _unpause();
     }
+
+    /// @notice Mint shares for any prefunded assets
+    function syncPrefundedAssets(address receiver) external onlyOwner {
+        uint256 currentAssets = IERC20(asset()).balanceOf(address(this));
+        uint256 represented = convertToAssets(totalSupply());
+        if (currentAssets > represented) {
+            uint256 unaccounted = currentAssets - represented;
+            _mint(receiver, unaccounted);
+        }
+    }
     
     /// @notice Check if caller is authorized (vault owner, AI controller, or fee collector)
     function isAuthorized(address caller) external view returns (bool) {


### PR DESCRIPTION
## Summary
- initialize fee collector high water mark with current balance
- add syncPrefundedAssets to handle prefunded tokens
- allow emergency module to pause AI controller and expose pause functions
- add helper to record controller operations for testing
- update tests for new logic and prefunding behaviour

## Testing
- `forge test --via-ir -vvv`

------
https://chatgpt.com/codex/tasks/task_e_6881209a63a0832d878d1d467bdb1f37